### PR TITLE
Network NG: Move Interfaces to InterfacesCollection

### DIFF
--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -142,13 +142,13 @@ module Yast
         },
         "MTU"          => mtu_widget,
         "IFCFGTYPE"    => {
-          "widget"            => :combobox,
+          "widget" => :combobox,
           # ComboBox label
-          "label"             => _("&Device Type"),
-          "opt"               => [:hstretch, :notify],
-          "help"              => "",
+          "label"  => _("&Device Type"),
+          "opt"    => [:hstretch, :notify],
+          "help"   => "",
           # "items" will be filled in the dialog itself
-          "init"              => fun_ref(
+          "init"   => fun_ref(
             method(:initIfcfg),
             "void (string)"
           )

--- a/src/lib/y2network/config_reader/sysconfig.rb
+++ b/src/lib/y2network/config_reader/sysconfig.rb
@@ -74,7 +74,7 @@ module Y2Network
           name = item["ifcfg"] || item["hwinfo"]["dev_name"]
           Y2Network::Interface.new(name)
         end
-        Y2Network::Interfaces.new(interfaces)
+        Y2Network::InterfacesCollection.new(interfaces)
       end
 
       # Load a set of routes for a given path

--- a/src/lib/y2network/config_reader/sysconfig.rb
+++ b/src/lib/y2network/config_reader/sysconfig.rb
@@ -35,8 +35,7 @@ module Y2Network
 
       # @return [Y2Network::Config] Network configuration
       def config
-        # LanItems has to be already initialized
-        interfaces = Y2Network::Interfaces.new.from_lan_items(Yast::LanItems.Items)
+        interfaces = find_interfaces
         routing_tables = find_routing_tables(interfaces.select(&:configured))
         routing = Routing.new(
           tables: routing_tables, forward_ipv4: forward_ipv4?, forward_ipv6: forward_ipv6?
@@ -64,6 +63,18 @@ module Y2Network
         all_routes = main_routes + iface_routes
         link_routes_to_interfaces(all_routes, interfaces)
         [Y2Network::RoutingTable.new(all_routes.uniq)]
+      end
+
+      # Returns the list of network interfaces
+      #
+      # @return [Array<Interface>] Interfaces
+      def find_interfaces
+        # LanItems has to be already initialized
+        interfaces = Yast::LanItems.Items.map do |_index, item|
+          name = item["ifcfg"] || item["hwinfo"]["dev_name"]
+          Y2Network::Interface.new(name)
+        end
+        Y2Network::Interfaces.new(interfaces)
       end
 
       # Load a set of routes for a given path

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -77,8 +77,8 @@ module Y2Network
 
     # Updates itself according to the given sysconfig configuration
     #
-    # @param [Hash<String, String>] a key, value map where key is sysconfig option
-    #                               and corresponding value is the option value
+    # @param devmap [Hash<String, String>] a key, value map where key is sysconfig option and
+    #                                      corresponding value is the option value
     def load_sysconfig(devmap)
       @config = !devmap.nil? ? @config.merge(devmap) : @config
     end

--- a/src/lib/y2network/interface_defaults.rb
+++ b/src/lib/y2network/interface_defaults.rb
@@ -22,7 +22,6 @@ require "yaml"
 
 module Y2Network
   module InterfaceDefaults
-
     # returns default startmode for a new device
     #
     # startmode is returned according product, Arch and current device type

--- a/src/lib/y2network/interfaces.rb
+++ b/src/lib/y2network/interfaces.rb
@@ -34,39 +34,19 @@ module Y2Network
 
     extend Forwardable
 
-    def_delegator :@old_items, :each
-    def_delegator :@old_items, :map
-    def_delegator :@old_items, :select
+    def_delegators :@old_items, :each, :map, :select
 
-    # Converts old LanItems::Items into internal data format
-    #
-    # @return [Interfaces] a container with available interfaces
-    def from_lan_items(lan_items)
-      # FIXME: should be replaced, separating backend from old API
-      @old_items = hash_to_interface(lan_items)
-      self
+    # @param interfaces [Array<Interface>] List of interfaces
+    def initialize(interfaces)
+      @old_items = interfaces
     end
 
     def find(name)
-      @old_items.find { |i| !i.name.nil? ? i.name == name : i.hardware.name }
+      old_items.find { |i| !i.name.nil? ? i.name == name : i.hardware.name }
     end
 
     def add(name)
-      @old_items.push Interface.new(name)
-    end
-
-  private
-
-    # Converts old LanItems::Items into new format
-    #
-    # @param hash [Hash] a set of interfaces in LanItems::Items format
-    # @return [Array<Interface>] a list of interfaces obtained from the hash
-    def hash_to_interface(hash)
-      hash.map do |_, iface|
-        # one of those has to exist in LanItems::Items
-        name = iface["ifcfg"] || iface["hwinfo"]["dev_name"]
-        Interface.new(name)
-      end
+      old_items.push(Interface.new(name))
     end
   end
 end

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -47,14 +47,14 @@ module Y2Network
       @interfaces = interfaces
     end
 
-    # @param [String] Returns the interface with the given name
+    # @param name [String] Returns the interface with the given name
     def find(name)
       interfaces.find { |i| !i.name.nil? ? i.name == name : i.hardware.name }
     end
 
     # Add an interface with the given name
     #
-    # @param [String] Interface's name
+    # @param name [String] Interface's name
     def add(name)
       interfaces.push(Interface.new(name))
     end

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -25,7 +25,7 @@ module Y2Network
   #
   # FIXME: Intended for LanItems::Items separation
   # proper cleanup is must
-  class Interfaces
+  class InterfacesCollection
     # FIXME: Direct access to be replaced to make possible
     # Y2Network::Config.interfaces.eth0
     # Y2Network::Config.interfaces.of_type(:eth)

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -20,33 +20,43 @@
 require "forwardable"
 
 module Y2Network
-  # A container for network devices. In the end should carry methods for mass operations
-  # over network interfaces like old LanItems::find_dhcp_ifaces or so.
+  # A container for network devices. In the end should implement methods for mass operations over
+  # network interfaces like old LanItems::find_dhcp_ifaces.
   #
-  # FIXME: Intended for LanItems::Items separation
-  # proper cleanup is must
+  # @example Create a new collection
+  #   eth0 = Y2Network::Interface.new("eth0")
+  #   collection = Y2Network::InterfacesCollection.new(eth0)
+  #
+  # @example Find an interface using its name
+  #   iface = collection.find("eth0") #=> #<Y2Network::Interface:0x...>
   class InterfacesCollection
     # FIXME: Direct access to be replaced to make possible
     # Y2Network::Config.interfaces.eth0
     # Y2Network::Config.interfaces.of_type(:eth)
     # ...
-    attr_reader :old_items
+    attr_reader :interfaces
 
     extend Forwardable
 
-    def_delegators :@old_items, :each, :map, :select
+    def_delegators :@interfaces, :each, :map, :select
 
+    # Constructor
+    #
     # @param interfaces [Array<Interface>] List of interfaces
     def initialize(interfaces)
-      @old_items = interfaces
+      @interfaces = interfaces
     end
 
+    # @param [String] Returns the interface with the given name
     def find(name)
-      old_items.find { |i| !i.name.nil? ? i.name == name : i.hardware.name }
+      interfaces.find { |i| !i.name.nil? ? i.name == name : i.hardware.name }
     end
 
+    # Add an interface with the given name
+    #
+    # @param [String] Interface's name
     def add(name)
-      old_items.push(Interface.new(name))
+      interfaces.push(Interface.new(name))
     end
   end
 end

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -1437,8 +1437,8 @@ module Yast
           bullets += ip_overview(iface.config) if iface.config["STARTMODE"] != "managed"
 
           if iface.type == "wlan" &&
-             iface.config["WIRELESS_AUTH_MODE"] == "open" &&
-             iface.config.fetch("WIRELESS_KEY_0", {}).empty?
+              iface.config["WIRELESS_AUTH_MODE"] == "open" &&
+              iface.config.fetch("WIRELESS_KEY_0", {}).empty?
 
             # avoid colons
             ifcfg_name = iface.name.tr(":", "/")
@@ -1945,9 +1945,9 @@ module Yast
       # #104494 - always write IPADDR+NETMASK, even empty
       # newdev["IPADDR"] = @ipaddr
       # if !@prefix.empty?
-        # newdev["PREFIXLEN"] = @prefix
+      # newdev["PREFIXLEN"] = @prefix
       # else
-        # newdev["NETMASK"] = @netmask
+      # newdev["NETMASK"] = @netmask
       # end
       # #50955 omit computable fields
       newdev["BROADCAST"] = ""
@@ -1968,10 +1968,10 @@ module Yast
         end
       end
 
-#      newdev["ZONE"] = @firewall_zone
-#      newdev["NAME"] = @description
+      #      newdev["ZONE"] = @firewall_zone
+      #      newdev["NAME"] = @description
 
-#      newdev = setup_basic_device_options(newdev)
+      #      newdev = setup_basic_device_options(newdev)
       newdev = setup_dhclient_options(newdev)
 
       # FIXME: network-ng currently works for eth only

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -30,7 +30,7 @@ require "network/lan_items_summary"
 require "y2network/config"
 
 require "y2network/config"
-require "y2network/interfaces"
+require "y2network/interfaces_collection"
 
 require "shellwords"
 

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -1320,7 +1320,7 @@ module Yast
 
     # Creates item's startmode human description
     #
-    # @param item_id [Integer] a key for {#Items}
+    # @param ifcfg [Hash] Interface sysconfig configuration
     def startmode_overview(ifcfg)
       startmode_descrs = {
         # summary description of STARTMODE=auto
@@ -1553,7 +1553,7 @@ module Yast
     end
 
     # Select the hardware component
-    # @param hardware the component
+    # @param iface [Y2Network::Interface] Network interface
     def SelectHWMap(iface)
       # FIXME: check in depth whether it is needed
       # - currently it seems to be useless (an attempt for virtual method which

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -1320,8 +1320,8 @@ module Yast
 
     # Creates item's startmode human description
     #
-    # @param ifcfg [Hash] Interface sysconfig configuration
-    def startmode_overview(ifcfg)
+    # @param devmap [Hash] Interface sysconfig configuration
+    def startmode_overview(devmap)
       startmode_descrs = {
         # summary description of STARTMODE=auto
         "auto"    => _(
@@ -1353,7 +1353,7 @@ module Yast
         )
       }
 
-      startmode_descr = startmode_descrs[ifcfg["STARTMODE"].to_s] || _("Started manually")
+      startmode_descr = startmode_descrs[devmap["STARTMODE"].to_s] || _("Started manually")
 
       [startmode_descr]
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,8 @@ end
 
 require "yast"
 require "yast/rspec"
+require "y2network/config"
+require "y2network/routing"
 Yast.import "Lan"
 
 require_relative "SCRStub"

--- a/test/y2network/interfaces_collection_test.rb
+++ b/test/y2network/interfaces_collection_test.rb
@@ -1,0 +1,42 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+require_relative "../test_helper"
+require "y2network/interfaces_collection"
+
+describe Y2Network::InterfacesCollection do
+  subject(:collection) { described_class.new(interfaces) }
+
+  let(:eth0) { Y2Network::Interface.new("eth0") }
+  let(:wlan0) { Y2Network::Interface.new("wlan0") }
+  let(:interfaces) { [eth0, wlan0] }
+
+  describe "#find" do
+    it "returns the interface with the given name" do
+      expect(collection.find("eth0")).to eq(eth0)
+    end
+  end
+
+  describe "#add" do
+    it "adds an interface with the given name" do
+      collection.add("eth1")
+      eth1 = collection.find("eth1")
+      expect(eth1.name).to eq("eth1")
+    end
+  end
+end


### PR DESCRIPTION
* Move `Y2Network::Interfaces` is moved to `Y2Network::InterfacesCollection`.
* Add unit tests.
* Move interfaces reading to `ConfigReader::Sysconfig`.